### PR TITLE
dcm2niix most common compression "-z y" requires pigz lib

### DIFF
--- a/Singularity
+++ b/Singularity
@@ -32,6 +32,7 @@ apt-get install -y zlib1g-dev
 apt-get install -y libwrap0-dev 
 apt-get install -y libssl-dev
 apt-get install -y dcm2niix
+apt-get install -y pigz
 
 mkdir /data
 

--- a/getting-started/Dockerfile
+++ b/getting-started/Dockerfile
@@ -14,6 +14,7 @@ ADD run.sh /code
 RUN apt-get update && apt-get install -y build-essential \
                                          cmake  \
                                          dcm2niix \
+                                         pigz \
                                          wget \
                                          vim \
                                          libpng-dev \


### PR DESCRIPTION
dcm2niix, in it's most common use case, is run with "-z y", which allows for (parallel) compression. This requires pigz.