### PR TITLE
dcmtk updated to 3.6.5

### DIFF
--- a/getting-started/Dockerfile
+++ b/getting-started/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER vsochat@stanford.edu
 # VERSION=$(cat VERSION)
 # docker build -t pydicom/dicom:v${VERSION} .
 
-ENV DCMTK_VERSION=dcmtk-3.6.4
-ENV DCMTK_PREFIX=/opt/dcmtk364
+ENV DCMTK_VERSION=dcmtk-3.6.5
+ENV DCMTK_PREFIX=/opt/dcmtk365
 ENV PATH=$PATH:${DCMTK_PREFIX}/bin:/opt/conda/bin
 
 RUN mkdir /code


### PR DESCRIPTION
3.6.4 is no longer available at the release location for download; bumped to 3.6.5. To close #10